### PR TITLE
Slight Mods to Script

### DIFF
--- a/githump.sh
+++ b/githump.sh
@@ -77,14 +77,14 @@ function get_org_emails() {
     # -----------------------------------------------------------
     # clone the repo and extract email addresses
     # -----------------------------------------------------------
-    git clone -q "${repo}"
+    git clone -n -q "${repo}"
     cd ${repo_dir}
-    git log | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" >> "${output_file}"
+    git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" >> "${output_file}"
 
     # -----------------------------------------------------------
     # update user with status
     # -----------------------------------------------------------
-    total=$(git log | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" | wc -l)
+    total=$(git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" | wc -l)
     [ $total -gt 0 ] && log_success "Dumped ${total} email addresses to ${output_file}"
 
     # -----------------------------------------------------------
@@ -112,14 +112,14 @@ function get_user_emails() {
     # -----------------------------------------------------------
     # clone the repo and extract email addresses
     # -----------------------------------------------------------
-    git clone -q "${repo}"
+    git clone -n -q "${repo}"
     cd ${repo_dir}
-    git log | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" >> "${output_file}"
+    git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" >> "${output_file}"
 
     # -----------------------------------------------------------
     # update user with status
     # -----------------------------------------------------------
-    total=$(git log | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" | wc -l)
+    total=$(git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" | wc -l)
     [ $total -gt 0 ] && log_success "Dumped ${total} email addresses to ${output_file}"
 
     # -----------------------------------------------------------


### PR DESCRIPTION
1. Modified the "git clone" command to have the -n flag, which doesn't perform a checkout and only pulls the meta. (Much faster)
2. Modified the "git log" command to have the --all flag, which will grab commits for all branches and not just the one cloned.