### PR TITLE
Modified Regex for Underscores in Addresses

### DIFF
--- a/githump.sh
+++ b/githump.sh
@@ -98,12 +98,12 @@ function get_org_emails() {
     # -----------------------------------------------------------
     git clone -n -q "${repo}"
     cd ${repo_dir}
-    git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" >> "${output_file}"
+    git log --all | grep "^Author:" | egrep -o "\b[a-zA-Z0-9.-.*\d_]+@[a-zA-Z0-9.-.*\d_]+\.[a-zA-Z0-9.-.*\d_]+\b" | sort -u >> "${output_file}"
 
     # -----------------------------------------------------------
     # update user with status
     # -----------------------------------------------------------
-    total=$(git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" | wc -l)
+    total=$(git log --all | grep "^Author:" | egrep -o "\b[a-zA-Z0-9.-.*\d_]+@[a-zA-Z0-9.-.*\d_]+\.[a-zA-Z0-9.-.*\d_]+\b" | sort -u | wc -l)
     [ $total -gt 0 ] && log_success "Dumped ${total} email addresses to ${output_file}"
 
     # -----------------------------------------------------------
@@ -133,12 +133,12 @@ function get_user_emails() {
     # -----------------------------------------------------------
     git clone -n -q "${repo}"
     cd ${repo_dir}
-    git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" >> "${output_file}"
+    git log --all | grep "^Author:" | egrep -o "\b[a-zA-Z0-9.-.*\d_]+@[a-zA-Z0-9.-.*\d_]+\.[a-zA-Z0-9.-.*\d_]+\b" | sort -u >> "${output_file}"
 
     # -----------------------------------------------------------
     # update user with status
     # -----------------------------------------------------------
-    total=$(git log --all | grep "^Author:" | sort | uniq | egrep -o "\b[a-zA-Z0-9.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9.-]+\b" | wc -l)
+    total=$(git log --all | grep "^Author:" | egrep -o "\b[a-zA-Z0-9.-.*\d_]+@[a-zA-Z0-9.-.*\d_]+\.[a-zA-Z0-9.-.*\d_]+\b" | sort -u | wc -l)
     [ $total -gt 0 ] && log_success "Dumped ${total} email addresses to ${output_file}"
 
     # -----------------------------------------------------------


### PR DESCRIPTION
john.smith@example.com would be extracted, but john_smith@example.com would not.

1. Modified the email address regex match to include emails that contain an underscore (".*\d_")
2. Switched the location of sort & uniq to the end of the grep, and used sort - u vs. | to uniq